### PR TITLE
カラム追加機能を実装

### DIFF
--- a/app/components/add-column-button.tsx
+++ b/app/components/add-column-button.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { createColumn } from "@/app/actions/board";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Plus, Check, X } from "lucide-react";
+
+interface AddColumnButtonProps {
+  boardId: string;
+  onColumnAdded?: () => void;
+}
+
+const colorOptions = [
+  { label: "赤", value: "#ef4444" },
+  { label: "オレンジ", value: "#f59e0b" },
+  { label: "黄色", value: "#eab308" },
+  { label: "緑", value: "#10b981" },
+  { label: "青", value: "#3b82f6" },
+  { label: "紫", value: "#8b5cf6" },
+  { label: "ピンク", value: "#ec4899" },
+  { label: "グレー", value: "#6b7280" },
+];
+
+export function AddColumnButton({ boardId, onColumnAdded }: AddColumnButtonProps) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [title, setTitle] = useState("");
+  const [selectedColor, setSelectedColor] = useState(colorOptions[0].value);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = () => {
+    if (!title.trim()) return;
+
+    const formData = new FormData();
+    formData.append("title", title.trim());
+    formData.append("color", selectedColor);
+    formData.append("boardId", boardId);
+
+    startTransition(async () => {
+      const result = await createColumn(formData);
+      if (result.success) {
+        setTitle("");
+        setSelectedColor(colorOptions[0].value);
+        setIsAdding(false);
+        onColumnAdded?.();
+      } else {
+        console.error("Failed to create column:", result.errors);
+      }
+    });
+  };
+
+  const handleCancel = () => {
+    setTitle("");
+    setSelectedColor(colorOptions[0].value);
+    setIsAdding(false);
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSubmit();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  if (isAdding) {
+    return (
+      <div className="min-w-80 bg-muted/50 rounded-lg p-4 space-y-3">
+        <Input
+          type="text"
+          placeholder="カラム名を入力..."
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={handleKeyPress}
+          className="w-full"
+          autoFocus
+          disabled={isPending}
+        />
+        
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground">カラーを選択:</p>
+          <div className="flex gap-2 flex-wrap">
+            {colorOptions.map((color) => (
+              <button
+                key={color.value}
+                type="button"
+                onClick={() => setSelectedColor(color.value)}
+                className={`w-6 h-6 rounded-full border-2 transition-all ${
+                  selectedColor === color.value
+                    ? "border-foreground scale-110"
+                    : "border-border hover:border-foreground/50"
+                }`}
+                style={{ backgroundColor: color.value }}
+                title={color.label}
+                disabled={isPending}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!title.trim() || isPending}
+            className="flex-1"
+          >
+            <Check className="h-4 w-4 mr-1" />
+            {isPending ? "追加中..." : "追加"}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCancel}
+            disabled={isPending}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      className="min-w-80 h-auto p-4 border-2 border-dashed border-muted-foreground/25 hover:border-muted-foreground/50 hover:bg-muted/50 transition-all"
+      onClick={() => setIsAdding(true)}
+    >
+      <Plus className="h-5 w-5 mr-2" />
+      新しいカラムを追加
+    </Button>
+  );
+}

--- a/app/components/kanban-board.tsx
+++ b/app/components/kanban-board.tsx
@@ -14,7 +14,9 @@ import {
 import { arrayMove } from "@dnd-kit/sortable";
 import { Board, Column, Task } from "@prisma/client";
 import { DroppableColumn } from "./droppable-column";
+import { AddColumnButton } from "./add-column-button";
 import { moveTask } from "../actions/task";
+import { useRouter } from "next/navigation";
 
 interface KanbanBoardProps {
   board: Board & {
@@ -27,6 +29,7 @@ export function KanbanBoard({ board }: KanbanBoardProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const router = useRouter();
 
   // Sync state with props when board data changes
   useEffect(() => {
@@ -142,6 +145,10 @@ export function KanbanBoard({ board }: KanbanBoardProps) {
     return columns.find((col) => col.tasks.some((t) => t.id === taskId)) || null;
   };
 
+  const handleColumnAdded = () => {
+    router.refresh();
+  };
+
   return (
     <DndContext
       sensors={sensors}
@@ -157,6 +164,7 @@ export function KanbanBoard({ board }: KanbanBoardProps) {
             isOver={overId === column.id}
           />
         ))}
+        <AddColumnButton boardId={board.id} onColumnAdded={handleColumnAdded} />
       </div>
 
       <DragOverlay dropAnimation={null}>


### PR DESCRIPTION
- カンバンボードに「+ 新しいカラムを追加」ボタンを最右端に配置
- インライン入力フィールドとカラーパレットによるカラム作成UI
- カラム名のバリデーション（空文字チェック）
- 8色のプリセットカラーパレット
- Enter/Escapeキーショートカットサポート
- 最右端への自動配置機能
- 追加後の自動リフレッシュ機能

🤖 Generated with [Claude Code](https://claude.ai/code)