### PR TITLE
期限切れタスクの視覚的強調表示機能を実装

### DIFF
--- a/app/components/draggable-task.tsx
+++ b/app/components/draggable-task.tsx
@@ -3,6 +3,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Task } from "@prisma/client";
+import { isTaskOverdue, getOverdueRelativeTime } from "@/lib/utils";
 
 interface DraggableTaskProps {
   task: Task;
@@ -23,6 +24,9 @@ export function DraggableTask({ task }: DraggableTaskProps) {
     transition,
   };
 
+  const isOverdue = isTaskOverdue(task.dueDate);
+  const overdueText = getOverdueRelativeTime(task.dueDate);
+
   return (
     <div
       ref={setNodeRef}
@@ -31,9 +35,16 @@ export function DraggableTask({ task }: DraggableTaskProps) {
       {...listeners}
       className={`bg-background p-3 rounded-md border shadow-sm hover:shadow-md transition-all duration-200 cursor-grab active:cursor-grabbing ${
         isDragging ? "opacity-50 shadow-lg scale-105 rotate-2" : ""
-      }`}
+      } ${isOverdue ? "border-red-500 border-2" : ""}`}
     >
-      <h4 className="font-medium text-sm mb-1">{task.title}</h4>
+      <div className="flex items-start gap-2 mb-1">
+        <h4 className="font-medium text-sm flex-1">{task.title}</h4>
+        {isOverdue && (
+          <span className="text-red-500 text-sm" title="期限切れ">
+            ⚠️
+          </span>
+        )}
+      </div>
       {task.description && (
         <p className="text-xs text-muted-foreground mb-2">{task.description}</p>
       )}
@@ -58,9 +69,16 @@ export function DraggableTask({ task }: DraggableTaskProps) {
             : "低"}
         </span>
         {task.dueDate && (
-          <span className="text-xs text-muted-foreground">
-            {new Date(task.dueDate).toLocaleDateString("ja-JP")}
-          </span>
+          <div className="flex flex-col items-end">
+            <span className={`text-xs ${isOverdue ? "text-red-500 font-medium" : "text-muted-foreground"}`}>
+              {new Date(task.dueDate).toLocaleDateString("ja-JP")}
+            </span>
+            {isOverdue && (
+              <span className="text-xs text-red-500 font-medium">
+                {overdueText}
+              </span>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/app/components/droppable-column.tsx
+++ b/app/components/droppable-column.tsx
@@ -5,6 +5,7 @@ import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { Column, Task } from "@prisma/client";
 import { DraggableTask } from "./draggable-task";
 import { AddTaskDialog } from "./add-task-dialog";
+import { isTaskOverdue } from "@/lib/utils";
 
 interface DroppableColumnProps {
   column: Column & { tasks: Task[] };
@@ -15,6 +16,8 @@ export function DroppableColumn({ column, isOver }: DroppableColumnProps) {
   const { setNodeRef } = useDroppable({
     id: column.id,
   });
+
+  const overdueTasksCount = column.tasks.filter(task => isTaskOverdue(task.dueDate)).length;
 
   return (
     <div
@@ -32,6 +35,11 @@ export function DroppableColumn({ column, isOver }: DroppableColumnProps) {
         <span className="text-sm text-muted-foreground">
           ({column.tasks.length})
         </span>
+        {overdueTasksCount > 0 && (
+          <span className="text-xs bg-red-100 text-red-700 px-2 py-1 rounded-full font-medium flex items-center gap-1">
+            ⚠️ {overdueTasksCount}
+          </span>
+        )}
       </div>
 
       <div className="space-y-3 min-h-[100px]">

--- a/app/components/kanban-board.tsx
+++ b/app/components/kanban-board.tsx
@@ -15,6 +15,7 @@ import { arrayMove } from "@dnd-kit/sortable";
 import { Board, Column, Task } from "@prisma/client";
 import { DroppableColumn } from "./droppable-column";
 import { moveTask } from "../actions/task";
+import { isTaskOverdue, getOverdueRelativeTime } from "@/lib/utils";
 
 interface KanbanBoardProps {
   board: Board & {
@@ -189,9 +190,16 @@ export function KanbanBoard({ board }: KanbanBoardProps) {
                   : "低"}
               </span>
               {activeTask.dueDate && (
-                <span className="text-xs text-muted-foreground">
-                  {new Date(activeTask.dueDate).toLocaleDateString("ja-JP")}
-                </span>
+                <div className="flex flex-col items-end">
+                  <span className={`text-xs ${isTaskOverdue(activeTask.dueDate) ? "text-red-500 font-medium" : "text-muted-foreground"}`}>
+                    {new Date(activeTask.dueDate).toLocaleDateString("ja-JP")}
+                  </span>
+                  {isTaskOverdue(activeTask.dueDate) && (
+                    <span className="text-xs text-red-500 font-medium">
+                      {getOverdueRelativeTime(activeTask.dueDate)}
+                    </span>
+                  )}
+                </div>
               )}
             </div>
           </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,25 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function isTaskOverdue(dueDate: Date | null | undefined): boolean {
+  if (!dueDate) return false
+  return new Date(dueDate) < new Date()
+}
+
+export function getOverdueRelativeTime(dueDate: Date | null | undefined): string {
+  if (!dueDate || !isTaskOverdue(dueDate)) return ""
+  
+  const now = new Date()
+  const due = new Date(dueDate)
+  const diffInMs = now.getTime() - due.getTime()
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24))
+  
+  if (diffInDays === 0) {
+    return "今日期限切れ"
+  } else if (diffInDays === 1) {
+    return "1日前に期限切れ"
+  } else {
+    return `${diffInDays}日前に期限切れ`
+  }
+}


### PR DESCRIPTION
- 期限切れタスクに赤い境界線と警告アイコンを表示
- 期限日を赤文字で表示し、相対時間（例：「3日前に期限切れ」）を追加
- カラムヘッダーに期限切れタスク数のバッジを表示
- ドラッグ&ドロップ時の表示にも期限切れ情報を適用
- 期限切れ判定と相対時間表示のユーティリティ関数を追加

🤖 Generated with [Claude Code](https://claude.ai/code)